### PR TITLE
fix(definition): return "result: null" when no definitions are available

### DIFF
--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -63,21 +63,17 @@ pub(crate) fn definition(request: Request) -> Result<Message> {
     return serde_json::from_value(request.params)
         .map(|params| {
             Message::Response(match definition::definition(params) {
-                Ok(definition) => {
-                    let result = definition
+                Ok(definition) => Response {
+                    id: request.id,
+                    result: definition
                         .and_then(|d| serde_json::to_value(GotoDefinitionResponse::Scalar(d)).ok())
-                        .or_else(|| Some(serde_json::value::Value::Null));
-                    log::debug!("responding with definition: {:?}", &result);
-                    Response {
-                        id: request.id,
-                        result,
-                        error: None,
-                    }
-                }
+                        .or_else(|| Some(serde_json::value::Value::Null)),
+                    error: None,
+                },
                 Err(err) => err.to_response(request.id),
             })
         })
-        .map_err(|err| Error::from(err));
+        .map_err(Error::from);
 }
 
 pub(crate) fn diagnostic(request: Request) -> Result<Message> {

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -65,8 +65,12 @@ pub(crate) fn definition(request: Request) -> Result<Message> {
             Message::Response(match definition::definition(params) {
                 Ok(definition) => Response {
                     id: request.id,
-                    result: definition
-                        .and_then(|d| serde_json::to_value(GotoDefinitionResponse::Scalar(d)).ok()),
+                    result: serde_json::to_value(
+                        definition
+                            .map(GotoDefinitionResponse::Scalar)
+                            .unwrap_or_else(|| GotoDefinitionResponse::Array(Vec::new())),
+                    )
+                    .ok(),
                     error: None,
                 },
                 Err(err) => err.to_response(request.id),


### PR DESCRIPTION
usually not including the `result` key or even returning an empty array is sufficient, but vscode requires this to be explicitly `null`.